### PR TITLE
reset the this.CUE.Token in order to do successfuly remove

### DIFF
--- a/index.js
+++ b/index.js
@@ -633,7 +633,9 @@ class BladeIron {
 	        {
 	                if (this.connected()) {
 	                        this.TokenABI  = this.web3.eth.contract(EIP20ABI);
-	                }
+			}
+			// reset this.CUE.Token first
+			this.CUE.Token={};
 	
 	                let rc = tokenList.map( (token) =>
 	                {


### PR DESCRIPTION
This is to fix the unwatchToken function. 
Here the issue is : when we watch token we add the token to the this.CUE.token. But when we unwatch the token we did not remove it from this.CUE.token. 
For Example:
if we watch token [A, B, C], then we call hotGroupInfo we will get A,B,C. after we unwatch token A, then call hotGroupInfo, we will still get A,B,C .